### PR TITLE
Add python3-qwt dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,6 +10,5 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <!-- Python packages for Qwt 6.1 are not yet available -->
-  <!--<run_depend>python-qt-bindings-qwt61</run_depend>-->
+  <run_depend>python3-qwt</run_depend>
 </package>


### PR DESCRIPTION
@clalancette Could I ask you for a review since we talked about this? Just a one-liner. Thanks!!

I want to make sure I'm doing this correctly. Since both -pip and non-pip keys were added (https://github.com/ros/rosdistro/pull/31201), should I use the -pip key to be available on all possible platforms, or should I use the non-pip key, since theoretically the -pip key users are supposed to eventually migrate to the non-pip key?

Do those new rosdep keys take effect immediately, so I can release this PR into Noetic, or do I need to wait for anything?